### PR TITLE
APC could not be installed, removed extra if

### DIFF
--- a/Command/AcceleratorCacheClearCommand.php
+++ b/Command/AcceleratorCacheClearCommand.php
@@ -144,30 +144,28 @@ class AcceleratorCacheClearCommand extends ContainerAwareCommand
         $success = true;
         $message = '';
 
-        if (function_exists('apc_clear_cache')) {
-            if ($clearUser) {
-                if (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '>=') && apc_clear_cache()) {
-                    $message .= ' APC User Cache: success.';
-                } elseif (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '<') && apc_clear_cache('user')) {
-                    $message .= ' APC User Cache: success.';
-                } elseif (function_exists('wincache_ucache_clear') && wincache_ucache_clear()) {
-                    $message .= ' Wincache User Cache: success.';
-                } else {
-                    $success = false;
-                    $message .= ' User Cache: failure';
-                }
+        if ($clearUser) {
+            if (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '>=') && apc_clear_cache()) {
+                $message .= ' APC User Cache: success.';
+            } elseif (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '<') && apc_clear_cache('user')) {
+                $message .= ' APC User Cache: success.';
+            } elseif (function_exists('wincache_ucache_clear') && wincache_ucache_clear()) {
+                $message .= ' Wincache User Cache: success.';
+            } else {
+                $success = false;
+                $message .= ' User Cache: failure';
             }
+        }
 
-            if ($clearOpcode) {
-                if (function_exists('opcache_reset') && opcache_reset()) {
-                    $message .= ' Zend OPcache: success.';
-                } elseif (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '<') && apc_clear_cache('opcode')) {
-                    $message .= ' APC Opcode Cache: success.';
-                }
-                else {
-                    $success = false;
-                    $message .= ' Opcode Cache: failure.';
-                }
+        if ($clearOpcode) {
+            if (function_exists('opcache_reset') && opcache_reset()) {
+                $message .= ' Zend OPcache: success.';
+            } elseif (function_exists('apc_clear_cache') && version_compare(PHP_VERSION, '5.5.0', '<') && apc_clear_cache('opcode')) {
+                $message .= ' APC Opcode Cache: success.';
+            }
+            else {
+                $success = false;
+                $message .= ' Opcode Cache: failure.';
             }
         }
 


### PR DESCRIPTION
Fixed use case when we have only OpCache installed and we want to clear the opcode cache.

Just removed the extra global condition:
`if (function_exists('apc_clear_cache')) {`
